### PR TITLE
feature/throttle-concurrency

### DIFF
--- a/src/main/java/com/github/cmalagacode/fhirunifier/api/config/CignaConfig.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/api/config/CignaConfig.java
@@ -12,6 +12,7 @@ public class CignaConfig implements Config {
     private String practitionerRoleURLParameter;
     private boolean oauth2;
     private String registrationId;
+    private boolean paginationSupported;
 
     public String getBaseURL() {
         return baseURL;
@@ -59,5 +60,13 @@ public class CignaConfig implements Config {
 
     public void setRegistrationId(String registrationId) {
         this.registrationId = registrationId;
+    }
+
+    public boolean getPaginationSupported() {
+        return paginationSupported;
+    }
+
+    public void setPaginationSupported(boolean paginationSupported) {
+        this.paginationSupported = paginationSupported;
     }
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/api/config/Config.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/api/config/Config.java
@@ -6,4 +6,5 @@ public interface Config {
     String getPractitionerRoleURLParameter();
     boolean getOauth2();
     String getRegistrationId();
+    boolean getPaginationSupported();
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/api/config/ElevanceHealthConfig.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/api/config/ElevanceHealthConfig.java
@@ -12,6 +12,7 @@ public class ElevanceHealthConfig implements Config {
     private String practitionerRoleURLParameter;
     private boolean oauth2;
     private String registrationId;
+    private boolean paginationSupported;
 
     public String getBaseURL() {
         return baseURL;
@@ -59,5 +60,13 @@ public class ElevanceHealthConfig implements Config {
 
     public void setRegistrationId(String registrationId) {
         this.registrationId = registrationId;
+    }
+
+    public boolean getPaginationSupported() {
+        return paginationSupported;
+    }
+
+    public void setPaginationSupported(boolean paginationSupported) {
+        this.paginationSupported = paginationSupported;
     }
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/api/config/HealthCareServiceCorporationConfig.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/api/config/HealthCareServiceCorporationConfig.java
@@ -12,6 +12,7 @@ public class HealthCareServiceCorporationConfig implements Config {
     private String practitionerRoleURLParameter;
     private boolean oauth2;
     private String registrationId;
+    private boolean paginationSupported;
 
     public String getBaseURL() {
         return baseURL;
@@ -59,5 +60,13 @@ public class HealthCareServiceCorporationConfig implements Config {
 
     public void setRegistrationId(String registrationId) {
         this.registrationId = registrationId;
+    }
+
+    public boolean getPaginationSupported() {
+        return paginationSupported;
+    }
+
+    public void setPaginationSupported(boolean paginationSupported) {
+        this.paginationSupported = paginationSupported;
     }
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/api/config/IndependenceBlueCrossConfig.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/api/config/IndependenceBlueCrossConfig.java
@@ -12,6 +12,7 @@ public class IndependenceBlueCrossConfig implements Config {
     private String practitionerRoleURLParameter;
     private boolean oauth2;
     private String registrationId;
+    private boolean paginationSupported;
 
     public String getBaseURL() {
         return baseURL;
@@ -59,5 +60,13 @@ public class IndependenceBlueCrossConfig implements Config {
 
     public void setRegistrationId(String registrationId) {
         this.registrationId = registrationId;
+    }
+
+    public boolean getPaginationSupported() {
+        return paginationSupported;
+    }
+
+    public void setPaginationSupported(boolean paginationSupported) {
+        this.paginationSupported = paginationSupported;
     }
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/api/config/KaiserPermanenteConfig.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/api/config/KaiserPermanenteConfig.java
@@ -13,6 +13,7 @@ public class KaiserPermanenteConfig implements Config {
     private String practitionerRoleURLParameter;
     private boolean oauth2;
     private String registrationId;
+    private boolean paginationSupported;
 
     public String getBaseURL() {
         return baseURL;
@@ -60,5 +61,13 @@ public class KaiserPermanenteConfig implements Config {
 
     public void setRegistrationId(String registrationId) {
         this.registrationId = registrationId;
+    }
+
+    public boolean getPaginationSupported() {
+        return paginationSupported;
+    }
+
+    public void setPaginationSupported(boolean paginationSupported) {
+        this.paginationSupported = paginationSupported;
     }
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/api/config/MolinaHealthcareConfig.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/api/config/MolinaHealthcareConfig.java
@@ -13,6 +13,7 @@ public class MolinaHealthcareConfig implements Config {
     private String practitionerRoleURLParameter;
     private boolean oauth2;
     private String registrationId;
+    private boolean paginationSupported;
 
     public String getBaseURL() {
         return baseURL;
@@ -60,5 +61,13 @@ public class MolinaHealthcareConfig implements Config {
 
     public void setRegistrationId(String registrationId) {
         this.registrationId = registrationId;
+    }
+
+    public boolean getPaginationSupported() {
+        return paginationSupported;
+    }
+
+    public void setPaginationSupported(boolean paginationSupported) {
+        this.paginationSupported = paginationSupported;
     }
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/api/config/UnitedHealthCareConfig.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/api/config/UnitedHealthCareConfig.java
@@ -13,6 +13,7 @@ public class UnitedHealthCareConfig implements Config {
     private String practitionerRoleURLParameter;
     private boolean oauth2;
     private String registrationId;
+    private boolean paginationSupported;
 
     public String getBaseURL() {
         return baseURL;
@@ -60,5 +61,13 @@ public class UnitedHealthCareConfig implements Config {
 
     public void setRegistrationId(String registrationId) {
         this.registrationId = registrationId;
+    }
+
+    public boolean getPaginationSupported() {
+        return paginationSupported;
+    }
+
+    public void setPaginationSupported(boolean paginationSupported) {
+        this.paginationSupported = paginationSupported;
     }
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/service/NPIRegistryClient.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/service/NPIRegistryClient.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
+
 
 @Service
 public class NPIRegistryClient {
@@ -25,6 +27,7 @@ public class NPIRegistryClient {
                         .build())
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
-                .bodyToMono(NPIRegistryResponse.class);
+                .bodyToMono(NPIRegistryResponse.class)
+                .timeout(Duration.ofSeconds(30));
     }
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/service/Oauth2FetchClient.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/service/Oauth2FetchClient.java
@@ -10,56 +10,95 @@ import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
+import java.time.Duration;
+import reactor.util.retry.Retry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class Oauth2FetchClient {
+    private static final Logger log = LoggerFactory.getLogger(Oauth2FetchClient.class);
+
     private final WebClient client;
 
     public Oauth2FetchClient(@Qualifier("oauth2WebClient") WebClient oauth2WebClient) {
         this.client = oauth2WebClient;
     }
 
-    public Mono<PractitionerRoleModel> fetchPractitionerRole(String url, String registrationId) {
+    private <T> Mono<T> fetchWithRetry(String url, String registrationId, Class<T> responseType, T emptyResponse) {
+        log.debug("Fetching {} from URL: {} with registrationId: {}",
+                responseType.getSimpleName(), url, registrationId);
+
         return client.get()
                 .uri(url)
-                .attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction.clientRegistrationId(registrationId))
+                .attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction
+                        .clientRegistrationId(registrationId))
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
-                .bodyToMono(PractitionerRoleModel.class)
-                .onErrorResume(e -> Mono.just(new PractitionerRoleModel()));
+                .bodyToMono(responseType)
+                .retryWhen(Retry.backoff(8, Duration.ofSeconds(3))
+                        .maxBackoff(Duration.ofSeconds(30))
+                        .jitter(0.75)
+                        .filter(throwable -> {
+                            if (throwable instanceof WebClientResponseException) {
+                                WebClientResponseException ex = (WebClientResponseException) throwable;
+                                // retry on 429 and 503
+                                return ex.getStatusCode().value() == 429 || ex.getStatusCode().value() == 503;
+                            }
+                            return false;
+                        })
+                        .doBeforeRetry(retrySignal -> {
+                            if (retrySignal.failure() instanceof WebClientResponseException) {
+                                WebClientResponseException ex = (WebClientResponseException) retrySignal.failure();
+                                String retryAfter = ex.getHeaders().getFirst("Retry-After");
+                                if (retryAfter != null) {
+                                    log.warn("Rate limited ({}). Retry-After: {} seconds. Attempt: {}/8",
+                                            ex.getStatusCode().value(),
+                                            retryAfter,
+                                            retrySignal.totalRetries() + 1);
+                                } else {
+                                    log.warn("Rate limited or service unavailable ({}). Retrying with backoff. Attempt: {}/8",
+                                            ex.getStatusCode().value(),
+                                            retrySignal.totalRetries() + 1);
+                                }
+                            }
+                        })
+                        .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
+                            log.error("Max retries exceeded for URL: {}. Original error: {}",
+                                    url, retrySignal.failure().getMessage());
+                            return retrySignal.failure();
+                        }))
+                .doOnSuccess(response -> {
+                    if (responseType == PractitionerRoleModel.class) {
+                        PractitionerRoleModel model = (PractitionerRoleModel) response;
+                        log.debug("Successfully fetched {}. Entry count: {}",
+                                responseType.getSimpleName(), model.getEntry() != null ? model.getEntry().size() : 0);
+                    } else {
+                        log.debug("Successfully fetched {} from URL: {}", responseType.getSimpleName(), url);
+                    }
+                })
+                .onErrorResume(e -> {
+                    log.error("Error fetching {} from URL: {}. Error: {}",
+                            responseType.getSimpleName(), url, e.getMessage());
+                    return Mono.just(emptyResponse);
+                });
+    }
+
+    public Mono<PractitionerRoleModel> fetchPractitionerRole(String url, String registrationId) {
+        return fetchWithRetry(url, registrationId, PractitionerRoleModel.class, new PractitionerRoleModel());
     }
 
     public Mono<PractitionerModel> fetchPractitioner(String url, String registrationId) {
-        return client.get()
-                .uri(url)
-                .attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction
-                        .clientRegistrationId(registrationId))
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(PractitionerModel.class)
-                .onErrorResume(e -> Mono.just(new PractitionerModel()));
+        return fetchWithRetry(url, registrationId, PractitionerModel.class, new PractitionerModel());
     }
 
     public Mono<OrganizationModel> fetchOrganization(String url, String registrationId) {
-        return client.get()
-                .uri(url)
-                .attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction
-                        .clientRegistrationId(registrationId))
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(OrganizationModel.class)
-                .onErrorResume(e -> Mono.just(new OrganizationModel()));
+        return fetchWithRetry(url, registrationId, OrganizationModel.class, new OrganizationModel());
     }
 
     public Mono<LocationModel> fetchLocation(String url, String registrationId) {
-        return client.get()
-                .uri(url)
-                .attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction
-                        .clientRegistrationId(registrationId))
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(LocationModel.class)
-                .onErrorResume(e -> Mono.just(new LocationModel()));
+        return fetchWithRetry(url, registrationId, LocationModel.class, new LocationModel());
     }
 }

--- a/src/main/java/com/github/cmalagacode/fhirunifier/service/SimpleFetchClient.java
+++ b/src/main/java/com/github/cmalagacode/fhirunifier/service/SimpleFetchClient.java
@@ -9,11 +9,19 @@ import org.springframework.http.MediaType;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
 
 
 @Service
 public class SimpleFetchClient {
+    private static final Logger log = LoggerFactory.getLogger(SimpleFetchClient.class);
 
     private final WebClient client;
 
@@ -21,39 +29,74 @@ public class SimpleFetchClient {
         this.client = simpleWebClient;
     }
 
-    public Mono<PractitionerRoleModel> fetchPractitionerRole(String url) {
+    private <T> Mono<T> fetchWithRetry(String url, Class<T> responseType, T emptyResponse) {
+        log.debug("Fetching {} from URL: {}", responseType.getSimpleName(), url);
+
         return client.get()
                 .uri(url)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
-                .bodyToMono(PractitionerRoleModel.class)
-                .onErrorResume(e -> Mono.just(new PractitionerRoleModel()));
+                .bodyToMono(responseType)
+                .retryWhen(Retry.backoff(8, Duration.ofSeconds(3))
+                        .maxBackoff(Duration.ofSeconds(30))
+                        .jitter(0.75)
+                        .filter(throwable -> {
+                            if (throwable instanceof WebClientResponseException) {
+                                WebClientResponseException ex = (WebClientResponseException) throwable;
+                                // retry on 429 and 503
+                                return ex.getStatusCode().value() == 429 || ex.getStatusCode().value() == 503;
+                            }
+                            return false;
+                        })
+                        .doBeforeRetry(retrySignal -> {
+                            if (retrySignal.failure() instanceof WebClientResponseException) {
+                                WebClientResponseException ex = (WebClientResponseException) retrySignal.failure();
+                                String retryAfter = ex.getHeaders().getFirst("Retry-After");
+                                if (retryAfter != null) {
+                                    log.warn("Rate limited ({}). Retry-After: {} seconds. Attempt: {}/8",
+                                            ex.getStatusCode().value(),
+                                            retryAfter,
+                                            retrySignal.totalRetries() + 1);
+                                } else {
+                                    log.warn("Rate limited or service unavailable ({}). Retrying in {} seconds. Attempt: {}/8",
+                                            ex.getStatusCode().value(),
+                                            retrySignal.totalRetries() + 1,
+                                            retrySignal.totalRetries() + 1);
+                                }
+                            }
+                        })
+                        .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
+                            log.error("Max retries exceeded for URL: {}. Original error: {}", url, retrySignal.failure().getMessage());
+                            return retrySignal.failure();
+                        }))
+                .doOnSuccess(response -> {
+                    if (responseType == PractitionerRoleModel.class) {
+                        PractitionerRoleModel model = (PractitionerRoleModel) response;
+                        log.debug("Successfully fetched {}. Entry count: {}",
+                                responseType.getSimpleName(), model.getEntry() != null ? model.getEntry().size() : 0);
+                    } else {
+                        log.debug("Successfully fetched {} from URL: {}", responseType.getSimpleName(), url);
+                    }
+                }).onErrorResume(e -> {
+                    log.error("Error fetching {} from URL: {}. Error: {}",
+                            responseType.getSimpleName(), url, e.getMessage());
+                    return Mono.just(emptyResponse);
+                });
+    }
+
+    public Mono<PractitionerRoleModel> fetchPractitionerRole(String url) {
+        return fetchWithRetry(url, PractitionerRoleModel.class, new PractitionerRoleModel());
     }
 
     public Mono<PractitionerModel> fetchPractitioner(String url) {
-        return client.get()
-                .uri(url)
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(PractitionerModel.class)
-                .onErrorResume(e -> Mono.just(new PractitionerModel()));
+        return fetchWithRetry(url, PractitionerModel.class, new PractitionerModel());
     }
 
     public Mono<OrganizationModel> fetchOrganization(String url) {
-        return client.get()
-                .uri(url)
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(OrganizationModel.class)
-                .onErrorResume(e -> Mono.just(new OrganizationModel()));
+        return fetchWithRetry(url, OrganizationModel.class, new OrganizationModel());
     }
 
     public Mono<LocationModel> fetchLocation(String url) {
-        return client.get()
-                .uri(url)
-                .accept(MediaType.APPLICATION_JSON)
-                .retrieve()
-                .bodyToMono(LocationModel.class)
-                .onErrorResume(e -> Mono.just(new LocationModel()));
+        return fetchWithRetry(url, LocationModel.class, new LocationModel());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-spring.mvc.async.request-timeout=5000
-server.error.whitelabel.enabled=false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ support:
     practitionerRoleURLQueryViaNPI: true
     oauth2: false
     registrationId: "cigna"
+    paginationSupported: true
   united-health-care:
     baseURL: "https://public.fhir.flex.optum.com/R4"
     practitionerRolePath: "PractitionerRole"
@@ -13,6 +14,7 @@ support:
     practitionerRoleURLQueryViaNPI: true
     oauth2: false
     registrationId: "united-health-care"
+    paginationSupported: true
   kaiser-permanente:
     baseURL: "https://kpx-service-bus.kp.org/service/hp/mhpo/healthplanproviderv1rc"
     practitionerRolePath: "PractitionerRole"
@@ -20,6 +22,7 @@ support:
     practitionerRoleURLQueryViaNPI: true
     oauth2: false
     registrationId: "kaiser-permanente"
+    paginationSupported: true
   independence-blue-cross:
     baseURL: "https://eapics.ibx.com/provider/v1/fhir"
     practitionerRolePath: "PractitionerRole"
@@ -27,6 +30,7 @@ support:
     practitionerRoleURLQueryViaNPI: true
     oauth2: false
     registrationId: "independence-blue-cross"
+    paginationSupported: false # IBX has broken pagination bug - next page token is expired as soon as current page loads
   molina-healthcare:
     baseURL: "https://api.interop.molinahealthcare.com/providerdirectory"
     practitionerRolePath: "PractitionerRole"
@@ -34,6 +38,7 @@ support:
     practitionerRoleURLQueryViaNPI: true
     oauth2: false
     registrationId: "molina-healthcare"
+    paginationSupported: true
   health-care-service-corporation:
     baseURL: "https://api.hcsc.net/providerfinder/sapphire/fhir"
     practitionerRolePath: "PractitionerRole"
@@ -41,6 +46,7 @@ support:
     practitionerRoleURLQueryViaNPI: true
     oauth2: false
     registrationId: "health-care-service-corporation"
+    paginationSupported: true
   elevance-health:
     baseURL: "https://totalview.healthos.elevancehealth.com/resources/unregistered/api/v1/fhir/cms_mandate/mcd"
     practitionerRolePath: "PractitionerRole"
@@ -48,7 +54,15 @@ support:
     practitionerRoleURLQueryViaNPI: true
     oauth2: true
     registrationId: "elevance-health"
+    paginationSupported: true
+server:
+  error:
+    whitelabel:
+      enabled: false
 spring:
+  mvc:
+    async:
+      request-timeout: 300000
   security:
     oauth2:
       client:
@@ -67,4 +81,5 @@ logging:
   level:
 #    com.github.cmalagacode.fhirunifier: DEBUG  # For development
     com.github.cmalagacode.fhirunifier: INFO  # For production
+
 


### PR DESCRIPTION
Throttle concurrency feature for slower external APIs. Implement exponential retries. Improve the next page query. Implement a temporary fix to the IBX API bug.IBX has a pagination bug. The next page token is expired as soon as the current page loads or soon after not allowing for next page query (401) since token is not valid. Improve API performance and increase async timeout. Improve overall timeout.