### PR TITLE
Patch Release Update Libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.5</version>
+        <version>3.5.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.github.cmalagacode.fhirunifier</groupId>
@@ -60,6 +60,16 @@
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
             <version>2.8.13</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>1.5.19</version> <!-- or newer -->
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.5.19</version> <!-- or newer -->
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
This patch addresses a security vulnerability flagged in transitive dependencies and ensures alignment with the latest stable Spring Boot release. Upgraded Spring Boot to 3.5.6 to incorporate security and stability improvements. Resolved CVE-2025-11226 by explicitly upgrading logback-core and logback-classic to 1.5.19. Updated transitive logging dependencies to mitigate known vulnerabilities. All users are encouraged to upgrade to this patch release to maintain a secure and stable environment.